### PR TITLE
Changes to implementation and test of iaf_psc_exp_ps_lossless for Nest PR #901

### DIFF
--- a/precise/iaf_psc_exp_ps_lossless.cpp
+++ b/precise/iaf_psc_exp_ps_lossless.cpp
@@ -661,19 +661,20 @@ nest::iaf_psc_exp_ps_lossless::is_spike_( const double dt )
      (I_theta-I_e, V_th) and (i2, f(i2)) where i2=(I_theta-I_e)*exp(dt/tau_s).
 
      Note that there is a typo in Algorithm 1 and 2 of the paper:
-     g and f are interchanged. (compare to Fig.6) 
+     g and f are interchanged. (compare to Fig.6)
   */
 
-  double f =
+  const double f =
     ( ( V_.a1_ * I_0 * exp_tau_m_s + exp_tau_m * ( V_.a3_ - I_e * V_.a2_ )
-        + V_.a3_ ) / V_.a4_ );
+        + V_.a3_ )
+      / V_.a4_ );
 
 
   // no-spike, NS_1, (V <= g_h,I_e(I) and V < f_h,I_e(I))
-  if ( ( V_0
-         < ( ( ( I_0 + I_e ) * ( V_.b1_ * exp_tau_m + V_.b2_ * exp_tau_s )
-                + V_.b3_ * ( exp_tau_m - exp_tau_s ) )
-              / ( V_.b4_ * exp_tau_s ) ) ) and ( V_0 <= f ) )
+  if ( ( V_0 < ( ( ( I_0 + I_e ) * ( V_.b1_ * exp_tau_m + V_.b2_ * exp_tau_s )
+                   + V_.b3_ * ( exp_tau_m - exp_tau_s ) )
+                 / ( V_.b4_ * exp_tau_s ) ) )
+    and ( V_0 <= f ) )
   {
     return numerics::nan;
   }
@@ -694,7 +695,7 @@ nest::iaf_psc_exp_ps_lossless::is_spike_( const double dt )
   // missed spike detected, S_2
   {
     return ( V_.a1_ / P_.tau_m_ * P_.tau_ex_ )
-      * std::log( V_.b1_ * I_0
-             / ( V_.a2_ * I_e - V_.a1_ * I_0 - V_.a4_ * V_0 ) );
+      * std::log(
+             V_.b1_ * I_0 / ( V_.a2_ * I_e - V_.a1_ * I_0 - V_.a4_ * V_0 ) );
   }
 }

--- a/precise/iaf_psc_exp_ps_lossless.cpp
+++ b/precise/iaf_psc_exp_ps_lossless.cpp
@@ -182,6 +182,14 @@ nest::iaf_psc_exp_ps_lossless::Parameters_::set( const DictionaryDatum& d )
     throw BadProperty( "Refractory time must not be negative." );
   }
 
+  if ( tau_ex_ != tau_in_ )
+  {
+    throw BadProperty(
+      "Exc. and inh. synapse time constants must be equal in the current implementation."
+      " If you need unequal time constants, use iaf_psc_exp_ps for now."
+      " See note in documentation, and github issue #921" );
+  }
+
   if ( tau_m_ <= 0 || tau_ex_ <= 0 || tau_in_ <= 0 )
   {
     throw BadProperty( "All time constants must be strictly positive." );
@@ -645,6 +653,9 @@ nest::iaf_psc_exp_ps_lossless::is_spike_( const double dt )
   // dt == 0 may occur if two spikes arrive simultaneously;
   // is_spike_() shall not be called then; see #368.
   assert( dt > 0 );
+
+  // synapse time constants are assumed to be equal in this implementation
+  assert( P_.tau_ex_ == P_.tau_in_ );
 
   const double I_0 = V_.I_syn_ex_before_ + V_.I_syn_in_before_;
   const double V_0 = V_.y2_before_;

--- a/precise/iaf_psc_exp_ps_lossless.cpp
+++ b/precise/iaf_psc_exp_ps_lossless.cpp
@@ -654,21 +654,32 @@ nest::iaf_psc_exp_ps_lossless::is_spike_( const double dt )
     numerics::expm1( dt / P_.tau_m_ - dt / P_.tau_ex_ );
   const double I_e = V_.y0_before_ + P_.I_e_;
 
-  double g =
+  /* Expressions for f and b below are rewritten but equivalent
+     to those given in Krishnan et al. 2018.
+     The expression for g given in the paper as eq.(49) is incorrect.
+     It can instead be constructed as a line through the points (see Fig.6):
+     (I_theta-I_e, V_th) and (i2, f(i2)) where i2=(I_theta-I_e)*exp(dt/tau_s).
+
+     Note that there is a typo in Algorithm 1 and 2 of the paper:
+     g and f are interchanged. (compare to Fig.6) 
+  */
+
+  double f =
     ( ( V_.a1_ * I_0 * exp_tau_m_s + exp_tau_m * ( V_.a3_ - I_e * V_.a2_ )
         + V_.a3_ ) / V_.a4_ );
 
-  // no-spike, NS_1, (V <= f_h,I_e(I) and V < g_h,I_e(I))
+
+  // no-spike, NS_1, (V <= g_h,I_e(I) and V < f_h,I_e(I))
   if ( ( V_0
-         <= ( ( ( I_0 + I_e ) * ( V_.b1_ * exp_tau_m + V_.b2_ * exp_tau_s )
+         < ( ( ( I_0 + I_e ) * ( V_.b1_ * exp_tau_m + V_.b2_ * exp_tau_s )
                 + V_.b3_ * ( exp_tau_m - exp_tau_s ) )
-              / ( V_.b4_ * exp_tau_s ) ) ) and ( V_0 < g ) )
+              / ( V_.b4_ * exp_tau_s ) ) ) and ( V_0 <= f ) )
   {
     return numerics::nan;
   }
 
-  // spike, S_1, V >= g_h,I_e(I)
-  else if ( V_0 >= g )
+  // spike, S_1, V >= f_h,I_e(I)
+  else if ( V_0 >= f )
   {
     return dt;
   }

--- a/precise/iaf_psc_exp_ps_lossless.cpp
+++ b/precise/iaf_psc_exp_ps_lossless.cpp
@@ -652,14 +652,15 @@ nest::iaf_psc_exp_ps_lossless::is_spike_( const double dt )
   const double exp_tau_m = numerics::expm1( dt / P_.tau_m_ );
   const double exp_tau_m_s =
     numerics::expm1( dt / P_.tau_m_ - dt / P_.tau_ex_ );
+  const double I_e = V_.y0_before_ + P_.I_e_;
 
   double g =
-    ( ( V_.a1_ * I_0 * exp_tau_m_s + exp_tau_m * ( V_.a3_ - P_.I_e_ * V_.a2_ )
+    ( ( V_.a1_ * I_0 * exp_tau_m_s + exp_tau_m * ( V_.a3_ - I_e * V_.a2_ )
         + V_.a3_ ) / V_.a4_ );
 
   // no-spike, NS_1, (V <= f_h,I_e(I) and V < g_h,I_e(I))
   if ( ( V_0
-         <= ( ( ( I_0 + P_.I_e_ ) * ( V_.b1_ * exp_tau_m + V_.b2_ * exp_tau_s )
+         <= ( ( ( I_0 + I_e ) * ( V_.b1_ * exp_tau_m + V_.b2_ * exp_tau_s )
                 + V_.b3_ * ( exp_tau_m - exp_tau_s ) )
               / ( V_.b4_ * exp_tau_s ) ) ) and ( V_0 < g ) )
   {
@@ -672,9 +673,9 @@ nest::iaf_psc_exp_ps_lossless::is_spike_( const double dt )
     return dt;
   }
   // no-spike, NS_2, V < b(I)
-  else if ( V_0 < ( V_.c1_ * P_.I_e_ + V_.c2_ * I_0
+  else if ( V_0 < ( V_.c1_ * I_e + V_.c2_ * I_0
                     + V_.c3_ * std::pow( I_0, V_.c4_ )
-                      * std::pow( ( V_.c5_ - P_.I_e_ ), V_.c6_ ) ) )
+                      * std::pow( ( V_.c5_ - I_e ), V_.c6_ ) ) )
   {
     return numerics::nan;
   }
@@ -683,6 +684,6 @@ nest::iaf_psc_exp_ps_lossless::is_spike_( const double dt )
   {
     return ( V_.a1_ / P_.tau_m_ * P_.tau_ex_ )
       * std::log( V_.b1_ * I_0
-             / ( V_.a2_ * P_.I_e_ - V_.a1_ * I_0 - V_.a4_ * V_0 ) );
+             / ( V_.a2_ * I_e - V_.a1_ * I_0 - V_.a4_ * V_0 ) );
   }
 }

--- a/precise/iaf_psc_exp_ps_lossless.cpp
+++ b/precise/iaf_psc_exp_ps_lossless.cpp
@@ -666,15 +666,13 @@ nest::iaf_psc_exp_ps_lossless::is_spike_( const double dt )
 
   const double f =
     ( ( V_.a1_ * I_0 * exp_tau_m_s + exp_tau_m * ( V_.a3_ - I_e * V_.a2_ )
-        + V_.a3_ )
-      / V_.a4_ );
+        + V_.a3_ ) / V_.a4_ );
 
 
   // no-spike, NS_1, (V <= g_h,I_e(I) and V < f_h,I_e(I))
   if ( ( V_0 < ( ( ( I_0 + I_e ) * ( V_.b1_ * exp_tau_m + V_.b2_ * exp_tau_s )
                    + V_.b3_ * ( exp_tau_m - exp_tau_s ) )
-                 / ( V_.b4_ * exp_tau_s ) ) )
-    and ( V_0 <= f ) )
+                 / ( V_.b4_ * exp_tau_s ) ) ) and ( V_0 <= f ) )
   {
     return numerics::nan;
   }

--- a/precise/iaf_psc_exp_ps_lossless.h
+++ b/precise/iaf_psc_exp_ps_lossless.h
@@ -73,6 +73,11 @@ Parameters:
   V_min         double - Absolute lower value for the membrane potential.
   V_reset       double - Reset value for the membrane potential.
 
+Note: In the current implementation, tau_syn_ex and tau_syn_in must be equal.
+  This is because the state space would be 3-dimensional otherwise, which
+  makes the detection of threshold crossing more difficult [1].
+  Support for different time constants may be added in the future, see issue #921.
+
 References:
 [1] Krishnan J, Porta Mana P, Helias M, Diesmann M and Di Napoli E
     (2018) Perfect Detection of Spikes in the Linear Sub-threshold

--- a/precise/iaf_psc_exp_ps_lossless.h
+++ b/precise/iaf_psc_exp_ps_lossless.h
@@ -224,8 +224,8 @@ private:
    * threshold line V < \theta, envelope, V > b(I_e) and line corresponding to
    * the final timestep
    * V > f(h, I) (or) linear approximation of the envelope, V < g(h, I_e).
-   * Propagate the neuron's state by dt.
-   * @returns time to emit spike.
+   * Note that in Algorithm 1 and 2 of [1], a typo interchanges g and f.
+   * @returns time interval in which threshold was crossed, or nan.
    */
   double is_spike_( const double );
 

--- a/testsuite/unittests/test_iaf_psc_exp_ps.sli
+++ b/testsuite/unittests/test_iaf_psc_exp_ps.sli
@@ -1,5 +1,5 @@
 /*
- *  test_iaf_psc_exp_ps_lossless.sli
+ *  test_iaf_psc_exp_ps.sli
  *
  *  This file is part of NEST.
  *
@@ -21,20 +21,13 @@
  */
 
  /* BeginDocumentation
-    Name: testsuite::test_iaf_psc_exp_ps_lossless - sli script for overall test of iaf_psc_exp_ps_lossless model
+    Name: testsuite::test_iaf_psc_exp_ps - sli script for overall test of iaf_psc_exp_ps model
 
-    Synopsis: (test_iaf_psc_exp_ps_lossless) run -> compares response to current step with reference data 
+    Synopsis: (test_iaf_psc_exp_ps) run -> compares response to current step with reference data 
 
     Description:
-    test_iaf_psc_exp_ps_lossless.sli is an overall test of the iaf_psc_exp_ps_lossless model connected
+    test_iaf_psc_exp_ps.sli is an overall test of the iaf_psc_exp_ps model connected
     to some useful devices.
-
-    The first part of this test is exactly the same as test_iaf_psc_exp_ps,
-    demonstrating the numerical equivalency of both models in usual conditions.
-    The only difference between the models, which is tested in the second part,
-    is the detection of double threshold crossings during a simulation step 
-    (so the membrane potential is again below V_th at the end of the step)
-    by the lossless model.
 
     A DC current is injected into the neuron using a current generator 
     device. The membrane potential as well as the spiking activity are 
@@ -62,7 +55,7 @@
     see the SeeAlso key below.    
 
     Author:  Jeyashree Krishnan, 2017
-    SeeAlso: iaf_psc_exp, testsuite::test_iaf_i0, testsuite::test_iaf_i0_refractory, testsuite::test_iaf_dc, testsuite::iaf_psc_exp_ps
+    SeeAlso: iaf_psc_exp, testsuite::test_iaf_i0, testsuite::test_iaf_i0_refractory, testsuite::test_iaf_dc, testsuite::test_iaf_psc_exp_ps_lossless
 */
 
 
@@ -78,7 +71,7 @@ ResetKernel
       /resolution h
   >> SetStatus
 
-/iaf_psc_exp_ps_lossless Create /neuron Set
+/iaf_psc_exp_ps Create /neuron Set
 
 /dc_generator Create /dc_gen Set
 dc_gen << /amplitude 1000. >> SetStatus
@@ -180,6 +173,4 @@ sp_det /events get /times get First stack    % prints spike time
 %
 
 exch assert_or_die
-
-% TODO: second part testing for region of missed spikes
 

--- a/testsuite/unittests/test_iaf_psc_exp_ps_lossless.sli
+++ b/testsuite/unittests/test_iaf_psc_exp_ps_lossless.sli
@@ -231,6 +231,7 @@ reset
 /iaf_psc_exp_ps_lossless << 
       /tau_m 100.
       /tau_syn_ex 1.
+      /tau_syn_in 1.
       /C_m 250.
       /V_th -49.
    >> SetDefaults

--- a/testsuite/unittests/test_iaf_psc_exp_ps_lossless.sli
+++ b/testsuite/unittests/test_iaf_psc_exp_ps_lossless.sli
@@ -23,7 +23,7 @@
  /* BeginDocumentation
     Name: testsuite::test_iaf_psc_exp_ps_lossless - sli script for overall test of iaf_psc_exp_ps_lossless model
 
-    Synopsis: (test_iaf_psc_exp_ps_lossless) run -> compares response to current step with reference data 
+    Synopsis: (test_iaf_psc_exp_ps_lossless) run -> compares response to current step with reference data and tests lossless spike detection
 
     Description:
     test_iaf_psc_exp_ps_lossless.sli is an overall test of the iaf_psc_exp_ps_lossless model connected
@@ -59,9 +59,36 @@
     call of vm below.
 
     Other test programs discuss the various aspects of this script in detail,
-    see the SeeAlso key below.    
+    see the SeeAlso key below.
 
-    Author:  Jeyashree Krishnan, 2017
+
+    The second part tests wether the lossless spike detection algorithm [1] is
+    working correctly.
+
+    The algorithm checks whether a spike is emitted on the basis of the neurons position 
+    in state space. There are 4 regions in state space (see [1]): NS1, NS2, S1 and S2.
+    S1 corresponds to threshold crossings that would also be detected by the lossy 
+    implementation /iaf_psc_exp_ps. S2 corresponds to crossings that would be missed.
+    The lossless model detects both.
+
+    The test brings 3 neurons into the state space regions NS2, S1 and S2,
+    which is done by keeping their membrane potential close to threshold and then 
+    sending a single spike to them, which, received via different synaptic weights,
+    sets the synaptic current such that the neurons are in the respective region.
+    The existence and precise times of the resulting spikes are compared to reference data.
+
+    If you need to reproduce the reference data, ask the authors of [1] for the script
+    regions_algorithm.py which they used to generate Fig. 6. Here you can adjust the
+    parameters as whished and obtain the respective regions. 
+    
+
+    References:
+    [1] Krishnan J, Porta Mana P, Helias M, Diesmann M and Di Napoli E
+        (2018) Perfect Detection of Spikes in the Linear Sub-threshold
+        Dynamics of Point Neurons. Front. Neuroinform. 11:75.
+        doi: 10.3389/fninf.2017.00075
+
+    Author:  Jeyashree Krishnan, 2017, and Christian Keup, 2018
     SeeAlso: iaf_psc_exp, testsuite::test_iaf_i0, testsuite::test_iaf_i0_refractory, testsuite::test_iaf_dc, testsuite::iaf_psc_exp_ps
 */
 
@@ -181,5 +208,110 @@ sp_det /events get /times get First stack    % prints spike time
 
 exch assert_or_die
 
-% TODO: second part testing for region of missed spikes
+
+
+
+%%%%%%%%%
+%
+% Beginning of 2nd part. Testing the spike detection algorithm 
+%
+
+ResetKernel
+
+reset
+
+(unittest) run
+/unittest using
+
+0 << 
+      /local_num_threads 1 
+      /resolution 1.     % low resolution is crucial.
+  >> SetStatus
+
+/iaf_psc_exp_ps_lossless << 
+      /tau_m 100.
+      /tau_syn_ex 1.
+      /C_m 250.
+      /V_th -49.
+   >> SetDefaults
+
+% 3 neurons that will test the detection of different types of threshold crossing
+/iaf_psc_exp_ps_lossless Create /nrn_nospike Set
+/iaf_psc_exp_ps_lossless Create /nrn_missingspike Set
+/iaf_psc_exp_ps_lossless Create /nrn_spike Set
+
+
+%syn weights of trigger spike that will put the nrn in the different state space regions
+55. /I_nospike Set
+70. /I_missingspike Set
+90. /I_spike Set
+
+%send one trigger spike to the nrns at specified time:
+
+/spike_generator << /precise_times true /spike_times [3.0] >> Create  /sp_gen  Set
+
+sp_gen nrn_nospike I_nospike 1. Connect
+sp_gen nrn_missingspike I_missingspike 1. Connect
+sp_gen nrn_spike I_spike 1. Connect
+
+
+%external current to keep nrns close to threshold:
+
+/dc_generator << /amplitude 52.5 >> Create  /dc_gen Set
+
+dc_gen nrn_nospike 1. 1. Connect
+dc_gen nrn_missingspike 1. 1. Connect
+dc_gen nrn_spike 1. 1. Connect
+
+
+%read out spike response of nrns:
+
+/spike_detector << /precise_times true >> SetDefaults
+
+/spike_detector Create /det_nospike Set
+nrn_nospike det_nospike Connect
+
+/spike_detector Create /det_missingspike Set
+nrn_missingspike det_missingspike Connect
+
+/spike_detector Create /det_spike Set
+nrn_spike det_spike Connect
+
+
+2 Simulate
+
+% set nrns close to threshold
+nrn_nospike << /V_m -49.001 >> SetStatus
+nrn_missingspike << /V_m -49.001 >> SetStatus
+nrn_spike << /V_m -49.001 >> SetStatus
+
+% swich off ext. current. This effect will reach the nrns at 3.0 due to syn delay,
+% so that the external current will be zero when the trigger spike arrives at 4.0 . 
+dc_gen << /amplitude 0. >> SetStatus  
+
+10 Simulate
+
+
+% get spike times
+
+det_nospike /events get /times get cva    % array of spike times (this one should be empty)
+  Total                                   % sum of array elements. works also for empty array
+  6 ToUnitTestPrecision
+  /time_nospike Set
+
+det_missingspike /events get /times get cva
+  Total
+  6 ToUnitTestPrecision
+  /time_missingspike Set
+
+det_spike /events get /times get cva
+  Total
+  6 ToUnitTestPrecision
+  /time_spike Set
+
+
+{ time_nospike 0 eq } assert_or_die
+{ time_missingspike 4.01442 eq } assert_or_die
+{ time_spike 4.00659 eq } assert_or_die
+
 


### PR DESCRIPTION
Resolves the problem I found in the spike detection algorithm and fixes the existing test.
The extension of the test to look at the region of missed spikes will follow after Easter.
For general comments please see Nest PR #901