### PR TITLE
Remove NESTError in server

### DIFF
--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -36,7 +36,6 @@ import RestrictedPython
 from flask import Flask, jsonify, request
 from flask.logging import default_handler
 from flask_cors import CORS
-from nest.lib.hl_api_exceptions import NESTError
 
 # This ensures that the logging information shows up in the console running the server,
 # even when Flask's event loop is running.
@@ -437,11 +436,6 @@ def get_or_error(func):
     def func_wrapper(call, *args, **kwargs):
         try:
             return func(call, *args, **kwargs)
-
-        except NESTError as err:
-            error_class = err.errorname + " (NESTError)"
-            detail = err.errormessage
-            lineno = get_lineno(err, 1)
 
         except (KeyError, SyntaxError, TypeError, ValueError) as err:
             error_class = err.__class__.__name__


### PR DESCRIPTION
Since NG it throws error because the file hl_api_exception cannot be found.
Thus, I removed NESTError from `hl_api_server.py`