### PR TITLE
Fix serialize data for nest server

### DIFF
--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -1261,7 +1261,7 @@ def serialize_data(data):
     """
 
     if isinstance(data, (numpy.ndarray, NodeCollection)):
-        return data.tolist()
+        return serialize_data(data.tolist())
     elif isinstance(data, SynapseCollection):
         # Get full information from SynapseCollection
         return serialize_data(data.get())
@@ -1274,7 +1274,7 @@ def serialize_data(data):
     if isinstance(data, (list, tuple)):
         return [serialize_data(d) for d in data]
     if isinstance(data, dict):
-        return dict([(key, serialize_data(value)) for key, value in data.items()])
+        return dict([(serialize_data(key), serialize_data(value)) for key, value in data.items()])
     return data
 
 


### PR DESCRIPTION
This PR patches the serialization error in which I occur in NEST Desktop script code to get positions.

I use following code lines:
```
pos = lambda n: dict(zip(n.global_id, nest.GetPosition(n)))
```
or 
```
def pos(n): return dict(zip(n.global_id, nest.GetPosition(n)))
```


However `node.global_id` is now numpy.int64 which cannot be serialized for JSON.


