### PR TITLE
Bump C++ standard to C++20

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: "Run cppcheck..."
         run: |
-          cppcheck --enable=all --language=c++ --std=c++17 -i sli/ --suppressions-list=.cppcheck_suppressions ./
+          cppcheck --enable=all --language=c++ --std=c++20 -i sli/ --suppressions-list=.cppcheck_suppressions ./
 
   rstcheck:
     runs-on: "ubuntu-22.04"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,9 @@ list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 
 project( nest CXX C )
 
-set( CMAKE_CXX_STANDARD 17 )
+set( CMAKE_CXX_STANDARD 20 )
 set( CMAKE_CXX_STANDARD_REQUIRED True )
-set( CMAKE_CXX_EXTENSIONS OFF )          # -std=c++17 instead of gnu++17
+set( CMAKE_CXX_EXTENSIONS OFF )          # -std=c++20 instead of gnu++20
 
 set( NEST_USER_EMAIL "users@nest-simulator.org" )
 

--- a/doc/htmldoc/developer_space/workflows/nest_with_ides.rst
+++ b/doc/htmldoc/developer_space/workflows/nest_with_ides.rst
@@ -148,7 +148,7 @@ Setting up the project
 
    a. *Cmake: Build Directory* to ``${workspaceFolder}/../build``
    #. *Cmake: Install Prefix* to ``${workspaceFolder}/../build/install``
-   #. *Cpp Standard* to ``c++17``
+   #. *Cpp Standard* to ``c++20``
 
 #. In the source directory, open ``.vscode/c_cpp_properties.json``, and add
 

--- a/nestkernel/connection_creator_impl.h
+++ b/nestkernel/connection_creator_impl.h
@@ -166,7 +166,7 @@ ConnectionCreator::PoolWrapper_< D >::PoolWrapper_()
 }
 
 template < int D >
-ConnectionCreator::PoolWrapper_< D >::~PoolWrapper_< D >()
+ConnectionCreator::PoolWrapper_< D >::~PoolWrapper_()
 {
   if ( masked_layer_ )
   {


### PR DESCRIPTION
This PR bumps the C++ standard from C++17 to C++20 which is required to use C++ concepts and modules.

This enables a bunch of follow-up code improvements:
- [ ] Stopwatch simplification: Using concepts instead of complex template logic (#37)
- [ ] CMake-to-C++ interface: Using compile-time-constants (`constexpr`) instead of C-macros ([#3399](https://github.com/nest/nest-simulator/issues/3399))
- [ ] `std::format` instead of `String::compose` (#38)
- [ ] `std::variant` instead of `boost::any` (#34)
- [ ] `KernelManager` refactoring and include-tree cleanup enabled by link-time optimization (LTO) ([#3544](https://github.com/nest/nest-simulator/pull/3544))
- [ ] C++20 modules to reduce compile-time