### PR TITLE
Refactor MPI command line construction in do_tests.sh

### DIFF
--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -140,8 +140,7 @@ if test "${HAVE_MPI}" = "True"; then
     MPI_LAUNCHER="$(get_build_info mpiexec)"
     MPI_LAUNCHER_VERSION="$($MPI_LAUNCHER --version | head -n1)"
     # TODO PyNEST-NG The two PREFLAGS variables are double up, as is some code further down relating to it. Sort out.
-    MPI_LAUNCHER_PREFLAGS="$(get_build_info mpiexec_preflags)"
-    MPIEXEC_PREFLAGS="--prefix $(python -c 'import sys; print(sys.prefix)')"
+    MPI_LAUNCHER_PREFLAGS="$(get_build_info mpiexec_preflags) --prefix $(python -c 'import sys; print(sys.prefix)')"
     # OpenMPI requires --oversubscribe to allow more processes than available cores
     #
     # ShellCheck warns about "SC2076 (warning): Remove quotes from right-hand side of =~ to match as a regex rather than literally.",
@@ -150,7 +149,6 @@ if test "${HAVE_MPI}" = "True"; then
     if [[ "${MPI_LAUNCHER_VERSION}" =~ "(OpenRTE)" ]] ||  [[ "${MPI_LAUNCHER_VERSION}" =~ "(Open MPI)" ]]; then
 	if [[ ! "$(get_build_info mpiexec_preflags)" =~ "--oversubscribe" ]]; then
 	    MPI_LAUNCHER_PREFLAGS="${MPI_LAUNCHER_PREFLAGS} --oversubscribe"
-        MPIEXEC_PREFLAGS="--oversubscribe $MPIEXEC_PREFLAGS"
 	fi
     fi
     MPI_LAUNCHER_NUMPROC_FLAG="$(get_build_info mpiexec_numproc_flag)"
@@ -264,7 +262,7 @@ if test "${MUSIC}"; then
 
         # Calculate the total number of processes from the '.music' file.
         np="$(($(sed -n 's/np=//p' "${music_file}" | paste -sd'+' -)))"
-        test_command="${MPI_LAUNCHER} ${MPIEXEC_PREFLAGS} -np ${np} ${MUSIC} ${test_name}"
+        test_command="${MPI_LAUNCHER_CMDLINE} -np ${np} ${MUSIC} ${test_name}"
 
         proc_txt="processes"
         if test $np -eq 1; then proc_txt="process"; fi


### PR DESCRIPTION
This PR cleans up how MPI is called in `do_tests.sh` for MUSIC tests to make it consistent with the other MPI tests.